### PR TITLE
Add mirrored full-screen video

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A browser-only hand recognition application with finger brush functionality and 
 * **Finger Brush**: Draw on an HTML `<canvas>` by pointing with your index finger. Both hands are supported; the right hand draws in a default dark blue ink and the left in white (customizable).
 * **Gesture Controls**: Activate HTML buttons by hovering your index finger over them for 1.5 seconds, indicated by a radial progress overlay.
 * **Color Sampling Mode**: Sample brush color from the live camera feed a short distance ahead of your fingertip each animation frame.
+* **Mirrored Full Screen Video**: The camera feed fills the entire browser window and is displayed like a mirror for easier interaction.
 
 ### Control Buttons (HTML UI)
 

--- a/app.js
+++ b/app.js
@@ -23,12 +23,16 @@ let handColors = {Left: colorLeft.value, Right: colorRight.value};
 let prevPoints = {Left: null, Right: null};
 const hoverTimers = new Map();
 
-function resizeCanvases(width, height) {
+function resizeCanvases() {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
   [videoCanvas, drawCanvas].forEach(c => {
     c.width = width;
     c.height = height;
   });
 }
+
+window.addEventListener('resize', resizeCanvases);
 
 function clearDrawing() {
   drawCtx.clearRect(0, 0, drawCanvas.width, drawCanvas.height);
@@ -150,16 +154,17 @@ const camera = new Camera(videoElement, {
 camera.start();
 
 function onResults(results) {
-  resizeCanvases(results.image.width, results.image.height);
+  resizeCanvases();
   videoCtx.save();
   videoCtx.clearRect(0, 0, videoCanvas.width, videoCanvas.height);
+  videoCtx.translate(videoCanvas.width, 0);
+  videoCtx.scale(-1, 1);
   if (showVideo) {
     videoCtx.drawImage(results.image, 0, 0, videoCanvas.width, videoCanvas.height);
   } else {
     videoCtx.fillStyle = '#000';
     videoCtx.fillRect(0, 0, videoCanvas.width, videoCanvas.height);
   }
-  videoCtx.restore();
 
   if (results.multiHandLandmarks) {
     results.multiHandLandmarks.forEach((landmarks, index) => {
@@ -167,17 +172,17 @@ function onResults(results) {
       drawConnectors(videoCtx, landmarks, HAND_CONNECTIONS, {color: '#0f0'});
       drawLandmarks(videoCtx, landmarks, {color: '#0f0', fillColor: '#0f0'});
 
-      const x = landmarks[8].x * videoCanvas.width;
+      const x = (1 - landmarks[8].x) * videoCanvas.width;
       const y = landmarks[8].y * videoCanvas.height;
 
       const overControl = [btnVid, btnClear, btnColor, btnThick, btnSample, colorLeft, colorRight].some(el => within(el, x, y));
 
       if (isPointing(landmarks) && !overControl) {
         if (sampleMode) {
-          const base = landmarks[5];
-          const tip = landmarks[8];
-          const dx = (tip.x - base.x) * videoCanvas.width;
-          const dy = (tip.y - base.y) * videoCanvas.height;
+          const baseX = (1 - landmarks[5].x) * videoCanvas.width;
+          const baseY = landmarks[5].y * videoCanvas.height;
+          const dx = x - baseX;
+          const dy = y - baseY;
           const sx = x + dx * 0.5;
           const sy = y + dy * 0.5;
           handColors[hand] = sampleColor(sx, sy);
@@ -205,4 +210,5 @@ function onResults(results) {
     resetPoint('Right');
     ['btn-vid','btn-clear','btn-color','btn-thick','btn-sample','color-left','color-right'].forEach(cancelHover);
   }
+  videoCtx.restore();
 }

--- a/style.css
+++ b/style.css
@@ -12,12 +12,16 @@ body {
 
 #app {
   position: relative;
+  width: 100vw;
+  height: 100vh;
 }
 
 canvas {
   position: absolute;
   top: 0;
   left: 0;
+  width: 100%;
+  height: 100%;
 }
 
 #controls {


### PR DESCRIPTION
## Summary
- make the camera canvas fill the window
- mirror the video feed and coordinates
- mention mirrored full screen in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868fd867e98832aa34e98301fe38d35