### PR TITLE
Fix drawing clearing each frame

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,8 @@ function resizeCanvases() {
 }
 
 window.addEventListener('resize', resizeCanvases);
+// Set initial canvas sizes once on load
+resizeCanvases();
 
 function clearDrawing() {
   drawCtx.clearRect(0, 0, drawCanvas.width, drawCanvas.height);
@@ -154,7 +156,6 @@ const camera = new Camera(videoElement, {
 camera.start();
 
 function onResults(results) {
-  resizeCanvases();
   videoCtx.save();
   videoCtx.clearRect(0, 0, videoCanvas.width, videoCanvas.height);
   videoCtx.translate(videoCanvas.width, 0);


### PR DESCRIPTION
## Summary
- set canvas size once at load instead of each frame
- remove per-frame resizing that erased drawings

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_6869008c922c832a9de479845c19da9a