### PR TITLE
Add gesture debug overlay

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const btnThick = document.getElementById('btn-thick');
 const btnSample = document.getElementById('btn-sample');
 const colorLeft = document.getElementById('color-left');
 const colorRight = document.getElementById('color-right');
+const debugEl = document.getElementById('debug');
 
 let showVideo = true;
 let sampleMode = false;
@@ -22,6 +23,10 @@ const thicknesses = [2,4,6,8];
 let handColors = {Left: colorLeft.value, Right: colorRight.value};
 let prevPoints = {Left: null, Right: null};
 const hoverTimers = new Map();
+
+function setDebug(text) {
+  if (debugEl) debugEl.textContent = text;
+}
 
 function resizeCanvases() {
   const width = window.innerWidth;
@@ -74,6 +79,29 @@ function isPointing(lms) {
     !isFingerExtended(lms,12,10) &&
     !isFingerExtended(lms,16,14) &&
     !isFingerExtended(lms,20,18);
+}
+
+function isThumbsUp(lms) {
+  return isFingerExtended(lms,4,3) &&
+    !isFingerExtended(lms,8,6) &&
+    !isFingerExtended(lms,12,10) &&
+    !isFingerExtended(lms,16,14) &&
+    !isFingerExtended(lms,20,18);
+}
+
+function isOpenHand(lms) {
+  return isFingerExtended(lms,4,3) &&
+    isFingerExtended(lms,8,6) &&
+    isFingerExtended(lms,12,10) &&
+    isFingerExtended(lms,16,14) &&
+    isFingerExtended(lms,20,18);
+}
+
+function getGesture(lms) {
+  if (isPointing(lms)) return 'pointing';
+  if (isThumbsUp(lms)) return 'thumbs up';
+  if (isOpenHand(lms)) return 'open hand';
+  return 'unknown';
 }
 
 function within(element, x, y) {
@@ -174,6 +202,7 @@ function onResults(results) {
   }
 
   if (results.multiHandLandmarks) {
+    let debugParts = [];
     results.multiHandLandmarks.forEach((landmarks, index) => {
       const hand = results.multiHandedness[index].label; // Left or Right
       drawConnectors(videoCtx, landmarks, HAND_CONNECTIONS, {color: '#0f0'});
@@ -183,8 +212,10 @@ function onResults(results) {
       const y = landmarks[8].y * videoCanvas.height;
 
       const overControl = [btnVid, btnClear, btnColor, btnThick, btnSample, colorLeft, colorRight].some(el => within(el, x, y));
+      const gesture = getGesture(landmarks);
+      let msg = `${hand}: ${gesture}`;
 
-      if (isPointing(landmarks) && !overControl) {
+      if (gesture === 'pointing' && !overControl) {
         if (sampleMode) {
           const baseX = (1 - landmarks[5].x) * videoCanvas.width;
           const baseY = landmarks[5].y * videoCanvas.height;
@@ -196,7 +227,8 @@ function onResults(results) {
         }
         drawLine(hand, x, y);
         cancelHover(hand);
-      } else if (isPointing(landmarks) && overControl) {
+        msg += ` drawing (${Math.round(x)}, ${Math.round(y)}) color ${handColors[hand]}`;
+      } else if (gesture === 'pointing' && overControl) {
         resetPoint(hand);
         let triggered = false;
         if (within(btnVid, x, y)) triggered = updateHover('btn-vid');
@@ -207,15 +239,19 @@ function onResults(results) {
         if (!triggered && within(btnSample, x, y)) triggered = updateHover('btn-sample'); else cancelHover('btn-sample');
         if (!triggered && within(colorLeft, x, y)) startHover('color-left'); else cancelHover('color-left');
         if (!triggered && within(colorRight, x, y)) startHover('color-right'); else cancelHover('color-right');
+        msg += ' over control';
       } else {
         resetPoint(hand);
-      ['btn-vid','btn-clear','btn-color','btn-thick','btn-sample','color-left','color-right'].forEach(cancelHover);
+        ['btn-vid','btn-clear','btn-color','btn-thick','btn-sample','color-left','color-right'].forEach(cancelHover);
       }
+      debugParts.push(msg);
     });
+    setDebug(debugParts.join(' | '));
   } else {
     resetPoint('Left');
     resetPoint('Right');
     ['btn-vid','btn-clear','btn-color','btn-thick','btn-sample','color-left','color-right'].forEach(cancelHover);
+    setDebug('no hands');
   }
   videoCtx.restore();
 }

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     </div>
     <input type="color" id="color-left" class="color-picker" value="#ffffff">
     <input type="color" id="color-right" class="color-picker" value="#003366">
+    <div id="debug"></div>
   </div>
 
   <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -65,3 +65,15 @@ canvas {
 
 #color-left { left: 10px; }
 #color-right { right: 10px; }
+
+#debug {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.6);
+  padding: 4px 8px;
+  border-radius: 4px;
+  pointer-events: none;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- show debug status text at bottom of page
- add gesture detection for thumbs up and open hand
- display coordinates and color when drawing
- hook up gesture data to new on-screen overlay

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68690c1109b8832aa94c41284f20779e