### PR TITLE
Hide color palette until color mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,12 +221,16 @@ function enterColorMode() {
   appState.mode = Mode.COLOR;
   colorOverlay.classList.remove('hidden');
   sizeOverlay.classList.add('hidden');
+  colorLeft.classList.remove('hidden');
+  colorRight.classList.remove('hidden');
 }
 
 function exitModes() {
   appState.mode = Mode.DRAW;
   sizeOverlay.classList.add('hidden');
   colorOverlay.classList.add('hidden');
+  colorLeft.classList.add('hidden');
+  colorRight.classList.add('hidden');
 }
 
 function updateSizeOverlay() {

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
     </div>
     <div id="color-overlay" class="hidden"></div>
     <div id="mode-badge"></div>
-    <input type="color" id="color-left" class="color-picker" value="#ffffff">
-    <input type="color" id="color-right" class="color-picker" value="#003366">
+    <input type="color" id="color-left" class="color-picker hidden" value="#ffffff">
+    <input type="color" id="color-right" class="color-picker hidden" value="#003366">
     <div id="debug"></div>
   </div>
 


### PR DESCRIPTION
## Summary
- hide color picker inputs until color mode is activated
- show and hide color pickers when entering/exiting color mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68699cd803f4832ab97c5699924ce044