### PR TITLE
Update color picker visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Seven HTML `<button>` elements sit overlayed at the top center of the canvas:
 6. **SIZ**: Adjust brush thickness (1–100 px) via Brush-Size Mode.
 7. **CLR**: Choose brush color via Color-Select Mode.
 
-Additionally, two color-picker inputs (`<input type="color">`) on the left and right edges let users choose specific colors for each hand.
+Additionally, a color-picker input (`<input type="color">`) on the right edge lets you choose a specific color for the right hand. The left-edge color picker is hidden until Color-Select Mode is activated.
 
 ## Requirements
 
@@ -53,7 +53,7 @@ Additionally, two color-picker inputs (`<input type="color">`) on the left and r
 
    * Point with your index finger (all other fingers curled).
    * Move your finger to draw on the canvas. Drawing stops when over a control button or color picker.
-   * Choose specific brush colors for each hand via the color pickers.
+   * Choose brush colors using the right-hand color picker or, while in Color-Select Mode, the left-hand picker.
 
 2. **Button Activation**:
 

--- a/app.js
+++ b/app.js
@@ -221,12 +221,14 @@ function enterColorMode() {
   appState.mode = Mode.COLOR;
   colorOverlay.classList.remove('hidden');
   sizeOverlay.classList.add('hidden');
+  colorLeft.classList.remove('hidden');
 }
 
 function exitModes() {
   appState.mode = Mode.DRAW;
   sizeOverlay.classList.add('hidden');
   colorOverlay.classList.add('hidden');
+  colorLeft.classList.add('hidden');
 }
 
 function updateSizeOverlay() {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     </div>
     <div id="color-overlay" class="hidden"></div>
     <div id="mode-badge"></div>
-    <input type="color" id="color-left" class="color-picker" value="#ffffff">
+    <input type="color" id="color-left" class="color-picker hidden" value="#ffffff">
     <input type="color" id="color-right" class="color-picker" value="#003366">
     <div id="debug"></div>
   </div>


### PR DESCRIPTION
## Summary
- hide the left color picker until color mode is active
- update JavaScript functions to show/hide the picker
- document the new behavior

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68699ff8643c832aa45290bebf515a76