### PR TITLE
Fix color sampling from video

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Additionally, a color-picker input (`<input type="color">`) on the right edge le
 
    * Toggle sampling mode with the **SMP** button.
    * While active, the brush color updates every frame to match the video pixel under an offset from your fingertip.
+   * Sampling is performed before drawing the green hand overlay so the sampled color reflects the video content only.
 
 4. **Clearing & Toggle**:
 

--- a/app.js
+++ b/app.js
@@ -290,9 +290,6 @@ function onResults(results) {
         // they match the user's perspective
         if (hand === 'Left') hand = 'Right';
         else if (hand === 'Right') hand = 'Left';
-        drawConnectors(videoCtx, landmarks, HAND_CONNECTIONS, {color: '#0f0'});
-        drawLandmarks(videoCtx, landmarks, {color: '#0f0', fillColor: '#0f0'});
-
         const x = (1 - landmarks[8].x) * videoCanvas.width;
         const y = landmarks[8].y * videoCanvas.height;
 
@@ -367,6 +364,8 @@ function onResults(results) {
             swatchTimers.clear();
           }
         }
+        drawConnectors(videoCtx, landmarks, HAND_CONNECTIONS, {color: '#0f0'});
+        drawLandmarks(videoCtx, landmarks, {color: '#0f0', fillColor: '#0f0'});
         debugParts.push(msg);
       });
       setDebug(debugParts.join(' | '));


### PR DESCRIPTION
## Summary
- sample color before drawing green overlays
- clarify color sampling behavior in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686aa3b8a380832a86c8d188daabdf98